### PR TITLE
feat: allow setting threat exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module cloud_ids {
 | severity | The minimum alert severity level that is reported by the endpoint | `string` | `"INFORMATIONAL"` | no |
 | subnet\_list | Subnet list to monitor with Cloud IDS | `list(string)` | `null` | no |
 | tag\_list | Tag list to monitor with Cloud IDS | `list(string)` | `null` | no |
+| threat\_exceptions | Threat IDs excluded from generating alerts. Limit: 99 IDs. | `list(string)` | `[]` | no |
 | vpc\_network\_name | VPC network name for IDS | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cloud_ids_example/README.md
+++ b/examples/cloud_ids_example/README.md
@@ -55,3 +55,24 @@ From the root folder of this repo, run the following command:
 ```
 terraform destroy
 ```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| network\_region | Network region for IDS | `string` | `"us-east1"` | no |
+| network\_zone | Network zone for IDS | `string` | `"us-east1-b"` | no |
+| project\_id | Project ID to deploy resources | `string` | n/a | yes |
+| vpc\_network\_name | VPC network name for IDS | `string` | `"cloud-ids-vpc"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ids\_endpoint\_id | IDS Endpoint id |
+| ids\_endpoint\_severity | IDS Endpoint severity |
+| ids\_malicious\_attacker\_server | n/a |
+| ids\_victim\_server\_ip | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -34,11 +34,12 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 
 # Creating the IDS Endpoint ####
 resource "google_cloud_ids_endpoint" "ids_endpoint" {
-  name     = var.ids_name
-  location = var.network_zone
-  network  = "projects/${var.project_id}/global/networks/${var.vpc_network_name}"
-  severity = var.severity
-  project  = var.project_id
+  name              = var.ids_name
+  location          = var.network_zone
+  network           = "projects/${var.project_id}/global/networks/${var.vpc_network_name}"
+  severity          = var.severity
+  project           = var.project_id
+  threat_exceptions = var.threat_exceptions
   depends_on = [
     google_service_networking_connection.private_vpc_connection,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,12 @@ variable "severity" {
   default     = "INFORMATIONAL"
 }
 
+variable "threat_exceptions" {
+  type        = list(string)
+  description = "Threat IDs excluded from generating alerts. Limit: 99 IDs."
+  default     = []
+}
+
 variable "packet_mirroring_policy_name" {
   type        = string
   description = "Packet mirroring policy name"


### PR DESCRIPTION
Currently if you add threat exception in the UI, the module will try to remove it:

```
  # module.cloud-ids.google_cloud_ids_endpoint.ids_endpoint will be updated in-place
  ~ resource "google_cloud_ids_endpoint" "ids_endpoint" {
        id                       = "projects/demo-project/locations/us-east1-a/endpoints/cloud-ids"
        name                     = "cloud-ids"
      ~ threat_exceptions        = [
          - "12345",
        ]
        # (8 unchanged attributes hidden)
    }
```

This PR adds a new variable, which is an empty list by default, that allows adding threat exceptions.