### PR TITLE
feat: Make Service Network Connection optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module cloud_ids {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cidr\_ranges\_filter | IP CIDR ranges that apply as a filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. | `list(string)` | `[]` | no |
+| create\_service\_networking\_connection | Whether to create service networking connection and IP range. | `bool` | `true` | no |
 | direction\_filter | Direction of traffic to mirror. Possible values are INGRESS, EGRESS, and BOTH. | `string` | `"BOTH"` | no |
 | ids\_name | Cloud IDS instance name | `string` | `"cloud-ids"` | no |
 | ids\_private\_ip\_address | Cloud IDS private IP address | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,8 @@
 
 # Setup Private IP access ###
 resource "google_compute_global_address" "ids_private_ip" {
+  count = var.create_service_networking_connection ? 1 : 0
+
   name          = var.ids_private_ip_range_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
@@ -26,9 +28,11 @@ resource "google_compute_global_address" "ids_private_ip" {
 
 # Create Private Connection: ####
 resource "google_service_networking_connection" "private_vpc_connection" {
+  count = var.create_service_networking_connection ? 1 : 0
+
   network                 = "projects/${var.project_id}/global/networks/${var.vpc_network_name}"
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.ids_private_ip.name]
+  reserved_peering_ranges = [google_compute_global_address.ids_private_ip[0].name]
   depends_on              = [google_compute_global_address.ids_private_ip]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "direction_filter" {
   description = "Direction of traffic to mirror. Possible values are INGRESS, EGRESS, and BOTH."
   default     = "BOTH"
 }
+
+variable "create_service_networking_connection" {
+  type        = bool
+  description = "Whether to create service networking connection and IP range."
+  default     = true
+}


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/terraform-google-cloud-ids/issues/16

This PR adds a new optional variable `create_service_networking_connection` allowing to skip the creation of `servicenetworking` connection and IP range for it.

That is needed when Cloud IDS endpoint is provisioned in the VPC network where `servicenetworking` connection already exists.

The change is backward compatible. 